### PR TITLE
Add '-L' option to curl

### DIFF
--- a/eval/tools/bpipe/0.9.9.6/bpipe.config
+++ b/eval/tools/bpipe/0.9.9.6/bpipe.config
@@ -19,7 +19,7 @@ tools {
      install = """
          mkdir -p tools/bwa
          cd tools/bwa
-         curl -o bwa.tar.bz2 'http://internode.dl.sourceforge.net/project/bio-bwa/bwa-0.7.12.tar.bz2'
+         curl -L -o bwa.tar.bz2 'http://internode.dl.sourceforge.net/project/bio-bwa/bwa-0.7.12.tar.bz2'
          tar -xjf bwa.tar.bz2
          cd bwa-*
          make
@@ -43,7 +43,7 @@ tools {
          install = """
            mkdir -p tools/xhmm
            cd tools/xhmm      
-           curl -o master.zip https://bitbucket.org/statgen/xhmm/get/master.zip
+           curl -L -o master.zip https://bitbucket.org/statgen/xhmm/get/master.zip
            unzip -o master.zip
            mv statgen* trunk
            cd trunk         
@@ -105,7 +105,7 @@ tools {
       install = """
           mkdir -p tools/conifer
           cd tools/conifer
-          curl -o 'conifer-0.2.2.tar.gz' 'http://internode.dl.sourceforge.net/project/conifer/CoNIFER%200.2.2/conifer_v0.2.2.tar.gz'
+          curl -L -o 'conifer-0.2.2.tar.gz' 'http://internode.dl.sourceforge.net/project/conifer/CoNIFER%200.2.2/conifer_v0.2.2.tar.gz'
           tar -xzf conifer-0.2.2.tar.gz
           mv conifer_v0.2.2 0.2.2
       """


### PR DESCRIPTION
This allows curl to follow 302 redirects (especially useful for sourceforge urls for conifer and bwa). Without this, the source for these packages don't end up getting downloaded.

Alternatively, could have used wget...