### PR TITLE
Extract lumpy PE & SU info from vcf and pass it through to ximmer local_combined_cnvs.json output

### DIFF
--- a/src/main/groovy/SummarizeCNVs.groovy
+++ b/src/main/groovy/SummarizeCNVs.groovy
@@ -654,7 +654,7 @@ class SummarizeCNVs {
        return DEFAULT_JS_COLUMNS + 
            (refGenes?['cds']:[]) +
            (dbIds.collect { String dbId -> [dbId, dbId + 'Freq'] }.sum()?:[]) +
-           cnvCallers + cnvCallers.collect { it+"_qual" } + ['calls','details']
+           cnvCallers + cnvCallers.collect { it+"_qual" } + ['calls','details','extrainfo']
     }
     
     /**
@@ -674,11 +674,13 @@ class SummarizeCNVs {
         
         Map calls = [:]
         Map details = [:]
+        Map extrainfo = [:]
         for(String caller in cnvCallers) {
             if(cnv[caller]) {
                 calls[caller] = cnv[caller].all.collect { 
                     [it.from, it.to, it.quality] 
                 }
+                extrainfo[caller] = cnv[caller].all.collect { it.extrainfo?:{} }
                 
                 if(cnv[caller]?.best?.details)
                     details[caller] = cnv[caller].best.details
@@ -703,7 +705,7 @@ class SummarizeCNVs {
             cnv[caller].best ? "TRUE" : "FALSE"
         }  + cnvCallers.collect { caller ->
             cnv[caller].best ? cnv[caller].best.quality : 0
-        } + [calls] + details
+        } + [calls] + details + extrainfo
                
 		Map data = [columnNames,line].transpose().collectEntries()
         

--- a/src/main/groovy/ximmer/results/LumpyResults.groovy
+++ b/src/main/groovy/ximmer/results/LumpyResults.groovy
@@ -26,6 +26,7 @@ class LumpyResults extends CNVResults {
 			r.start = v.pos
 			r.end = v.info.END.toInteger()
 			r.quality = [v.info.PE?:0,v.info.SU?:0, v.info.SR?:0]*.toInteger().sum()
+			r.extrainfo = [PE:v.info.PE.toInteger()?:0,SU:v.info.SU.toInteger()?:0]
             
 			addRegion(r)
             


### PR DESCRIPTION
- Currently PE, SU & SR info are summed together so cannot be filtered on individually
- PE & SU are thus added separately under a new 'extrainfo' field
- These are then passed through to the local_combined_cnvs.json output where they can be used for filtering
- The 'extrainfo' field is available for all callers but will be passed through as an empty field if unpopulated